### PR TITLE
住所関連編集

### DIFF
--- a/develop/app/controllers/users/addresses_controller.rb
+++ b/develop/app/controllers/users/addresses_controller.rb
@@ -7,17 +7,17 @@ class Users::AddressesController < ApplicationController
   end
 
   def edit
-    @address = Address.find(params[:id])
+    @address = Address.where(user_id: current_user.id)
   end
 
   def create
     @address = Address.new(address_params)
     @address.user_id = current_user.id
     @address.save
-    if @address_id = 1 #編集中
+    if @address == current_user.addresses.first
       redirect_to users_items_path
     else
-      redirect_to edit_users_user_path
+      redirect_to edit_users_user_path(current_user)
     end
   end
 

--- a/develop/app/views/users/addresses/edit.html.erb
+++ b/develop/app/views/users/addresses/edit.html.erb
@@ -4,9 +4,10 @@
 
 
 <div class="container">
-　<h2>配送先追加</h2>
+　<h2>住所の編集</h2>
   <table>
-    <%= form_for(@address, url: users_addresses_path) do |f| %>
+    <% @address.each do |address| %>
+    <%= form_for(address, url: users_addresses_path) do |f| %>
     <tr>
       <th>氏名</th>
       <td>
@@ -46,6 +47,7 @@
     <tr>
       <%= f.submit 'この住所を追加する' %>
     </tr>
+    <% end %>
     <% end %>
   </table>
 </div>

--- a/develop/app/views/users/users/edit.html.erb
+++ b/develop/app/views/users/users/edit.html.erb
@@ -33,7 +33,7 @@
 			    		<%= link_to "住所追加",new_users_address_path,class: "col-lg-3 btn btn-default" %>
 			    		<%= link_to "住所の編集と削除",edit_users_address_path,class: "col-lg-3 btn btn-default" %><br>
 			    		<div class="form-group"><label for="artist_name"></label>
-			    			<br><%= f.select :address_id, Address.all.map{|t| [t.address, t.id]} %></div>
+			    			<br><%= f.select :address_id, @user.addresses.map{|t| [t.address, t.id]} %></div>
 			    	</div>
 			    </tr>
 			    <tr>


### PR DESCRIPTION
マイページの住所選択プルダウンをcurrent_useに基づいたものだけ表示するように編集

住所登録時と住所追加時は両方ともusers/addresses/newに飛ばすが、userの最初の登録の場合はitems/indexへ、それ以外の場合はusers/users/:id/editへ戻るように設定

users/addresses/editへ飛ばした時にcurrent_userに基づく住所のみ表示されるように編集